### PR TITLE
Fix to allow installing Yagi in user .idapro/plugins folder

### DIFF
--- a/yagi/src/yagi.cc
+++ b/yagi/src/yagi.cc
@@ -10,6 +10,8 @@
 #define NO_OBSOLETE_FUNCS
 #endif
 
+#include <sstream>
+
 #include <loader.hpp>
 #include <ida.hpp>
 #include <idp.hpp>
@@ -22,6 +24,15 @@
 #include "idasymbol.hh"
 #include "idalogger.hh"
 #include "loader.hh"
+
+// Path name separator
+#ifdef _WINDOWS
+#define PATH_SEP '\\'
+#else
+#define PATH_SEP '/'
+#endif
+
+
 
 
 static int processor_id() {
@@ -83,8 +94,26 @@ static yagi::Compiler compute_compiler() {
  */
 static plugmod_t* idaapi yagi_init(void)
 {
-	yagi::ghidra::init(idadir("plugins"));
+	qstrvec_t paths_list;
+	std::stringstream s;
+
 	auto logger = std::make_unique<yagi::IdaLogger>();
+
+	// Search Ghidra plugin installation path in $IDAUSR or $IDADIR
+	s << PLG_SUBDIR << PATH_SEP << "/Ghidra";
+	get_ida_subdirs(&paths_list, s.str().c_str(), IDA_SUBDIR_ONLY_EXISTING);
+
+	if (paths_list.empty()){
+		logger->error("Ghidra folder missing. Yagi was not correctly installed.");
+		return nullptr;
+	}
+
+	// Remove "/Ghidra" in the path
+	std::string ghidraPath(paths_list.at(0).c_str());
+	ghidraPath = ghidraPath.substr(0, ghidraPath.rfind(PATH_SEP));
+
+	yagi::ghidra::init(ghidraPath);
+
 	try
 	{
 		auto compilerId = compute_compiler();


### PR DESCRIPTION
Hi !

Currently Yagi can only be installed in Ida installation path, this fix allows installing Yagi in user $IDAUSR/plugins folder.
The function `get_ida_subdirs()` searches in `$IDAUSR`/ and `$IDADIR` folders and can be used to detect where Yagi is installed.

I only tested it on Linux but it should work on Windows too (if someone can test it before merging the PR ?)

